### PR TITLE
Update gulp-util to 3.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "babelify": "7.2.0",
     "browserify": "13.0.0",
     "gulp": "3.9.1",
-    "gulp-util": "2.9.7",
+    "gulp-util": "3.0.7",
     "vinyl-source-stream": "1.1.0"
   }
 }


### PR DESCRIPTION
The current version of gulp-util throws an error during npm install:

No compatible version found: gulp-util@2.9.7
