### PR TITLE
Changed the source for the bundle.js to src="./bundle.js"

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
 	<title>ES6</title>
 </head>
 <body>
-	
+
 	<h1>Nothing here, check the console!</h1>
 	<!-- One script to rule them all -->
-	<script src="/bundle.js"></script>
+	<script src="./bundle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Got an issue on MacOSX/Chrome this will fix it.

Due to a small typo, my browser couldn't locate the bundle.js file.
The change to src="./bundle.js" solved the issue.